### PR TITLE
Renamed MoveDirectory method as it was clashing with existing method

### DIFF
--- a/src/Cake.Extensions/DirectoryExtensions.cs
+++ b/src/Cake.Extensions/DirectoryExtensions.cs
@@ -23,7 +23,7 @@ namespace Cake.Extensions
         /// <exception cref="CakeException">Throws if source directory does not exist</exception>
         /// <exception cref="CakeException">Throws if destination directory does exist</exception>
         [CakeMethodAlias]
-        public static void MoveDirectory(this ICakeContext context, DirectoryPath source, DirectoryPath destination)
+        public static void TransferDirectory(this ICakeContext context, DirectoryPath source, DirectoryPath destination)
         {
             context.ThrowIfNull(nameof(context));
             source.ThrowIfNull(nameof(source));


### PR DESCRIPTION
A [method](https://github.com/cake-build/cake/blob/cf7cc86acca395b42b39338b061e31e1980d99c8/src/Cake.Common/IO/DirectoryAliases.cs#L456) with the same signature as `MainDirectory()`  exists in the main cake project (currently in preRelease only). 

This was causing the following error to be thrown when running a build:

> error CS0111: Type 'Submission#0' already defines a member called 'MoveDirectory' with the same parameter types

Renamed to `TransferDirectory()` to avoid collision.