### PR TITLE
Added a Dump() method to generate string representation of object

### DIFF
--- a/src/Cake.Extensions.Tests/Cake.Extensions.Tests.csproj
+++ b/src/Cake.Extensions.Tests/Cake.Extensions.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="CustomProjectParserTests.cs" />
     <Compile Include="DotNetBuildSettingsExtensionsTests.cs" />
     <Compile Include="FilePathExtensionTests.cs" />
+    <Compile Include="LoggingExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Cake.Extensions.Tests/LoggingExtensionsTests.cs
+++ b/src/Cake.Extensions.Tests/LoggingExtensionsTests.cs
@@ -1,0 +1,100 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+namespace Cake.Extensions.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using FluentAssertions;
+    using Xunit;
+
+    public class LoggingExtensionsTests
+    {
+        [Fact]
+        public void Dump_ReturnsNull_IfObjectNull()
+        {
+            object o = null;
+            o.Dump().Should().BeNullOrEmpty();
+        }
+
+        [Fact]
+        public void Dump_OutputsCorrectString_BasicProps()
+        {
+            var test = new DumpTest
+            {
+                IntProp = 99,
+                StringProp = "foo bar",
+                DateTimeProp = DateTime.Today
+            };
+
+            var expected =
+                $"StringProp: {test.StringProp}\r\nIntProp: {test.IntProp}\r\nDateTimeProp: {test.DateTimeProp}";
+
+            test.Dump().Should().Be(expected);
+        }
+
+        [Fact]
+        public void Dump_OutputsCorrectString_IEnumerableProps()
+        {
+            var test = new ListTest { ListProp = new List<string> { "foo", "bar" }, IntListProp = new[] { 1, 2, 3, 5 } };
+
+            const string expected = "ListProp: foo, bar\r\nIntListProp: 1, 2, 3, 5";
+
+            test.Dump().Should().Be(expected);
+        }
+
+        [Fact]
+        public void Dump_ToStringsCustomType()
+        {
+            var test = new Family
+            {
+                Parent = new Person("Older person", 42),
+                Children = new List<Person> { new Person("Toddler", 2), new Person("Teenager", 13) }
+            };
+
+            const string expected = "Parent: Older person is 42\r\nChildren: Toddler is 2, Teenager is 13";
+            test.Dump().Should().Be(expected);
+        }
+
+        private class DumpTest
+        {
+            public string StringProp { get; set; }
+            public int IntProp { get; set; }
+            public DateTime DateTimeProp { get; set; }
+            private string PrivateProp { get; set; }
+            public int Unreadable { private get; set; }
+
+            public DumpTest()
+            {
+                Unreadable = 180;
+                PrivateProp = "Private Prop";
+            }
+        }
+
+        private class ListTest
+        {
+            public IEnumerable<string> ListProp { get; set; }
+            public int[] IntListProp { get; set; }
+        }
+
+        private class Family
+        {
+            public Person Parent { get; set; }
+            public IEnumerable<Person> Children { get; set; }
+        }
+
+        private class Person
+        {
+            public string Name { get; }
+            public int Age { get; }
+
+            public Person(string name, int age)
+            {
+                Name = name;
+                Age = age;
+            }
+
+            public override string ToString() => $"{Name} is {Age}";
+        }
+    }
+}

--- a/src/Cake.Extensions/Cake.Extensions.csproj
+++ b/src/Cake.Extensions/Cake.Extensions.csproj
@@ -54,6 +54,7 @@
     <Compile Include="CustomProjectParserResult.cs" />
     <Compile Include="DirectoryExtensions.cs" />
     <Compile Include="DotNetCoreTestExtensions.cs" />
+    <Compile Include="LoggingExtensions.cs" />
     <Compile Include="ProjectTypes.cs" />
     <Compile Include="StringExtensions.cs" />
     <None Include="Cake.Extensions.nuspec" />

--- a/src/Cake.Extensions/LoggingExtensions.cs
+++ b/src/Cake.Extensions/LoggingExtensions.cs
@@ -1,0 +1,64 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+namespace Cake.Extensions
+{
+    using System.Collections;
+    using System.ComponentModel;
+    using System.Text;
+    using Core.Annotations;
+
+    [CakeAliasCategory("Logging")]
+    public static class LoggingExtensions
+    {
+        /// <summary>
+        /// Get a basic string representation of specified object.
+        /// </summary>
+        /// <typeparam name="T">Type of object</typeparam>
+        /// <param name="obj">Object to generate string representation of</param>
+        /// <returns>String representation of object in format in format "Prop: PropValue\r\nArrayProp: ArrayVal1, ArrayVal2"</returns>
+        [CakeMethodAlias]
+        public static string Dump<T>(this T obj)
+        {
+            if (obj == null) return null;
+
+            var dump = new StringBuilder();
+            foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(obj))
+            {
+                var propertyType = descriptor.PropertyType;
+                var value = descriptor.GetValue(obj);
+                if (propertyType.GetInterface("IEnumerable") != null && propertyType != typeof(string))
+                {
+                    ProcessEnumerable(value, dump, descriptor);
+                    continue;
+                }
+
+                dump.Append($"\r\n{descriptor.Name}: {value}");
+            }
+            
+            return dump.ToString().Remove(0, 2);
+        }
+
+        private static void ProcessEnumerable(object value, StringBuilder sb, MemberDescriptor descriptor)
+        {
+            // Is a collection, iterate and spit out value for each
+            var enumerable = value as IEnumerable;
+            if (enumerable == null) return;
+
+            var enumValues = new StringBuilder();
+            var first = true;
+            foreach (var val in enumerable)
+            {
+                if (first)
+                {
+                    enumValues.Append(val);
+                    first = false;
+                }
+                else
+                    enumValues.Append($", {val}");
+            }
+
+            sb.Append($"\r\n{descriptor.Name}: {enumValues}");
+        }
+    }
+}


### PR DESCRIPTION
This method is to help with logging in scripts. It takes all public properties and their values and outputs them. Values are derived by calling `ToString()`, if the value is an `IEnumerable` then the value will be a comma-delimited representation of values in enumerable.

It's worth noting that this is a fairly basic implementation at the moment and may fail with more complex object graphs.

Example usage in Cake script:
```csharp
var gitVersionResults = GitVersion(new GitVersionSettings());
Information("GitResults -> {0}", gitVersionResults.Dump());
```

which would provide output of:
```
GitResults -> Major: 0
Minor: 1
Patch: 0
PreReleaseTag: dev-19.1
PreReleaseTagWithDash: -dev-19.1
PreReleaseLabel: dev-19
PreReleaseNumber: 1
BuildMetaData: 26
..snip..
```