### PR TITLE
Added overload of ThrowIfNull to take custom message

### DIFF
--- a/src/Cake.Extensions.Tests/AssertExtensionTests.cs
+++ b/src/Cake.Extensions.Tests/AssertExtensionTests.cs
@@ -1,0 +1,22 @@
+﻿// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+namespace Cake.Extensions.Tests
+{
+    using System;
+    using FluentAssertions;
+    using Xunit;
+
+    public class AssertExtensionTests
+    {
+        [Fact]
+        public void ThrowIfNull_WithMessage_SetsMessage()
+        {
+            object obj = null;
+
+            Action action = () => obj.ThrowIfNull(nameof(obj), "This is required");
+            action.ShouldThrow<ArgumentNullException>().WithMessage(
+            "This is required\r\nParameter name: obj");
+        }
+    }
+}

--- a/src/Cake.Extensions.Tests/Cake.Extensions.Tests.csproj
+++ b/src/Cake.Extensions.Tests/Cake.Extensions.Tests.csproj
@@ -76,6 +76,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssertExtensionTests.cs" />
     <Compile Include="CustomProjectParserTests.cs" />
     <Compile Include="DotNetBuildSettingsExtensionsTests.cs" />
     <Compile Include="FilePathExtensionTests.cs" />

--- a/src/Cake.Extensions/AssertExtensions.cs
+++ b/src/Cake.Extensions/AssertExtensions.cs
@@ -16,6 +16,14 @@ namespace Cake.Extensions
             return obj;
         }
 
+        public static T ThrowIfNull<T>(this T obj, string varName, string message)
+        {
+            if (obj == null)
+                throw new ArgumentNullException(varName ?? "object", message);
+
+            return obj;
+        }
+
         public static string ThrowIfNullOrEmpty(this string strValue, string varName)
         {
             if (string.IsNullOrEmpty(strValue))

--- a/src/Cake.Extensions/LoggingExtensions.cs
+++ b/src/Cake.Extensions/LoggingExtensions.cs
@@ -6,9 +6,7 @@ namespace Cake.Extensions
     using System.Collections;
     using System.ComponentModel;
     using System.Text;
-    using Core.Annotations;
 
-    [CakeAliasCategory("Logging")]
     public static class LoggingExtensions
     {
         /// <summary>
@@ -17,7 +15,6 @@ namespace Cake.Extensions
         /// <typeparam name="T">Type of object</typeparam>
         /// <param name="obj">Object to generate string representation of</param>
         /// <returns>String representation of object in format in format "Prop: PropValue\r\nArrayProp: ArrayVal1, ArrayVal2"</returns>
-        [CakeMethodAlias]
         public static string Dump<T>(this T obj)
         {
             if (obj == null) return null;


### PR DESCRIPTION
Small change to allow ThrowIfNull to be used with a more informative message rather than the default "Value cannot be null".

Example usage in a cake script:

```csharp
var path = EnvironmentVariable("Path").ThrowIfNull("Path", "Environment Variable 'Path' not found");
```

Would throw error with message 
> Environment Variable 'Path' not found. Parameter name: Path