### PR TITLE
(#262) Cake v6.0.0 catch-up + bug-fixes + retrofit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-2025, ubuntu-24.04, macos-13 ]
+        os: [ windows-2025, ubuntu-24.04 ]
 
     env:
       AZURE_PASSWORD: ${{ secrets.AZURE_PASSWORD }}
@@ -46,6 +46,8 @@ jobs:
             6.0.x
             7.0.x
             8.0.x
+            9.0.x
+            10.0.x
 
       - name: Install mono
         if: runner.os == 'Linux'
@@ -72,6 +74,31 @@ jobs:
           target: CI
           verbosity: Normal
           cake-version: tool-manifest
+
+      # The demo/ folders exercise the just-built addin DLL under
+      # Cake-major-matching cake.tool / Cake.Frosting / Cake.Sdk
+      # versions. They run in their OWN tool/package context
+      # (independent of recipe.cake's cake.tool, which is constrained
+      # by Cake.Recipe's runtime). demo/script and demo/frosting
+      # consume the addin from BuildArtifacts/temp/_PublishedLibraries/
+      # populated by DotNetCore-Pack; demo/sdk builds the addin from
+      # source via the #:project directive in cake.cs.
+
+      - name: Run demo/script
+        if: success()
+        shell: pwsh
+        run: ./demo/script/build.ps1
+
+      - name: Run demo/frosting
+        if: success()
+        shell: pwsh
+        run: ./demo/frosting/build.ps1
+
+      - name: Run demo/sdk
+        if: success()
+        shell: pwsh
+        working-directory: ./demo/sdk
+        run: dotnet cake.cs
 
       - name: Upload Issues-Report
         uses: actions/upload-artifact@v5

--- a/demo/frosting/.gitignore
+++ b/demo/frosting/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+output/
+.vscode/

--- a/demo/frosting/build.ps1
+++ b/demo/frosting/build.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+
+Set-Location -LiteralPath $PSScriptRoot
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = '1'
+$env:DOTNET_NOLOGO = '1'
+
+dotnet run --project build/Build.csproj -- @args
+exit $LASTEXITCODE;

--- a/demo/frosting/build.sh
+++ b/demo/frosting/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+
+dotnet run --project build/Build.csproj -- "$@"

--- a/demo/frosting/build/Build.csproj
+++ b/demo/frosting/build/Build.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RunWorkingDirectory>$(MSBuildProjectDirectory)\</RunWorkingDirectory>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Cake.Incubator">
+      <HintPath>$(MSBuildProjectDirectory)\..\..\..\BuildArtifacts\temp\_PublishedLibraries\Cake.Incubator\net8.0\Cake.Incubator.dll</HintPath>
+    </Reference>
+    <PackageReference Include="Cake.Frosting" Version="6.1.0" />
+  </ItemGroup>
+</Project>

--- a/demo/frosting/build/BuildContext.cs
+++ b/demo/frosting/build/BuildContext.cs
@@ -1,0 +1,18 @@
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Frosting;
+
+namespace Build
+{
+    public class BuildContext : FrostingContext
+    {
+        public DirectoryPath WorkDir { get; } = "./BuildArtifacts/temp/test-incubator-frosting";
+
+        public FilePath SampleProject => WorkDir.CombineWithFilePath("Sample.csproj");
+
+        public BuildContext(ICakeContext context)
+            : base(context)
+        {
+        }
+    }
+}

--- a/demo/frosting/build/DefaultTask.cs
+++ b/demo/frosting/build/DefaultTask.cs
@@ -1,0 +1,11 @@
+using Build.Tasks;
+using Cake.Frosting;
+
+namespace Build
+{
+    [TaskName("Default")]
+    [IsDependentOn(typeof(CleanupTask))]
+    public sealed class DefaultTask : FrostingTask
+    {
+    }
+}

--- a/demo/frosting/build/Program.cs
+++ b/demo/frosting/build/Program.cs
@@ -1,0 +1,14 @@
+using Cake.Frosting;
+
+namespace Build
+{
+    public static class Program
+    {
+        public static int Main(string[] args)
+        {
+            return new CakeHost()
+                .UseContext<BuildContext>()
+                .Run(args);
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/CleanupTask.cs
+++ b/demo/frosting/build/Tasks/CleanupTask.cs
@@ -1,0 +1,23 @@
+using Cake.Common.Diagnostics;
+using Cake.Common.IO;
+using Cake.Frosting;
+
+namespace Build.Tasks
+{
+    [TaskName("Cleanup")]
+    [IsDependentOn(typeof(EnumerableExtensionsTask))]
+    public sealed class CleanupTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            if (context.DirectoryExists(context.WorkDir))
+            {
+                context.DeleteDirectory(
+                    context.WorkDir,
+                    new DeleteDirectorySettings { Recursive = true });
+            }
+
+            context.Information("Cleanup complete.");
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/EnumerableExtensionsTask.cs
+++ b/demo/frosting/build/Tasks/EnumerableExtensionsTask.cs
@@ -1,0 +1,31 @@
+using System;
+using Cake.Common.Diagnostics;
+using Cake.Frosting;
+using Cake.Incubator.EnumerableExtensions;
+
+namespace Build.Tasks
+{
+    [TaskName("Enumerable-Extensions")]
+    [IsDependentOn(typeof(StringExtensionsTask))]
+    public sealed class EnumerableExtensionsTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            string[] nullArray = null;
+            AssertThat(nullArray.IsNullOrEmpty(), "IsNullOrEmpty: null array should be true");
+            AssertThat(new string[0].IsNullOrEmpty(), "IsNullOrEmpty: empty array should be true");
+            AssertThat(!new[] { "a" }.IsNullOrEmpty(), "IsNullOrEmpty: non-empty array should be false");
+            AssertThat("foo".IsIn("foo", "bar", "baz"), "IsIn: 'foo' should be in list");
+            AssertThat(!"qux".IsIn("foo", "bar"), "IsIn: 'qux' should NOT be in list");
+            context.Information("Enumerable extensions OK (IsNullOrEmpty + IsIn)");
+        }
+
+        private static void AssertThat(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new Exception("Assertion failed: " + message);
+            }
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/ParseProjectTask.cs
+++ b/demo/frosting/build/Tasks/ParseProjectTask.cs
@@ -1,0 +1,32 @@
+using System;
+using Cake.Common.Diagnostics;
+using Cake.Frosting;
+using Cake.Incubator.Project;
+using Cake.Incubator.StringExtensions;
+
+namespace Build.Tasks
+{
+    [TaskName("Parse-Project")]
+    [IsDependentOn(typeof(SetupTask))]
+    public sealed class ParseProjectTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            var result = context.ParseProject(context.SampleProject, "Debug");
+            AssertThat(result != null, "ParseProject: returned null");
+            AssertThat(result.OutputType.EqualsIgnoreCase("Library"), "OutputType: expected Library, got " + result.OutputType);
+            AssertThat(result.AssemblyName == "SampleAddin", "AssemblyName: expected SampleAddin, got " + result.AssemblyName);
+            AssertThat(result.RootNameSpace == "Sample", "RootNameSpace: expected Sample, got " + result.RootNameSpace);
+            context.Information("ParseProject OK (OutputType={0}, AssemblyName={1}, RootNameSpace={2})",
+                result.OutputType, result.AssemblyName, result.RootNameSpace);
+        }
+
+        private static void AssertThat(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new Exception("Assertion failed: " + message);
+            }
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/SetupTask.cs
+++ b/demo/frosting/build/Tasks/SetupTask.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using Cake.Common.Diagnostics;
+using Cake.Common.IO;
+using Cake.Frosting;
+
+namespace Build.Tasks
+{
+    [TaskName("Setup")]
+    public sealed class SetupTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            if (context.DirectoryExists(context.WorkDir))
+            {
+                context.DeleteDirectory(
+                    context.WorkDir,
+                    new DeleteDirectorySettings { Recursive = true });
+            }
+
+            context.EnsureDirectoryExists(context.WorkDir);
+
+            File.WriteAllText(
+                context.MakeAbsolute(context.SampleProject).FullPath,
+                @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <AssemblyName>SampleAddin</AssemblyName>
+    <RootNamespace>Sample</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Cake.Core"" Version=""6.0.0"" />
+  </ItemGroup>
+</Project>");
+
+            context.Information("Setup complete.");
+        }
+    }
+}

--- a/demo/frosting/build/Tasks/StringExtensionsTask.cs
+++ b/demo/frosting/build/Tasks/StringExtensionsTask.cs
@@ -1,0 +1,29 @@
+using System;
+using Cake.Common.Diagnostics;
+using Cake.Frosting;
+using Cake.Incubator.StringExtensions;
+
+namespace Build.Tasks
+{
+    [TaskName("String-Extensions")]
+    [IsDependentOn(typeof(ParseProjectTask))]
+    public sealed class StringExtensionsTask : FrostingTask<BuildContext>
+    {
+        public override void Run(BuildContext context)
+        {
+            AssertThat("Hello".EqualsIgnoreCase("HELLO"), "EqualsIgnoreCase: case mismatch");
+            AssertThat("HelloWorld".StartsWithIgnoreCase("hello"), "StartsWithIgnoreCase: case mismatch");
+            AssertThat("HelloWorld".EndsWithIgnoreCase("WORLD"), "EndsWithIgnoreCase: case mismatch");
+            AssertThat(!"Hello".EqualsIgnoreCase("Goodbye"), "EqualsIgnoreCase: false-positive on different strings");
+            context.Information("String extensions OK (EqualsIgnoreCase + StartsWithIgnoreCase + EndsWithIgnoreCase)");
+        }
+
+        private static void AssertThat(bool condition, string message)
+        {
+            if (!condition)
+            {
+                throw new Exception("Assertion failed: " + message);
+            }
+        }
+    }
+}

--- a/demo/script/.config/dotnet-tools.json
+++ b/demo/script/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+    "version": 1,
+    "isRoot": true,
+    "tools": {
+        "cake.tool": {
+            "version": "6.1.0",
+            "commands": [
+                "dotnet-cake"
+            ]
+        }
+    }
+}

--- a/demo/script/build.ps1
+++ b/demo/script/build.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+
+Set-Location -LiteralPath $PSScriptRoot
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = '1'
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = '1'
+$env:DOTNET_NOLOGO = '1'
+
+dotnet tool restore
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+dotnet cake incubator.cake @args
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/demo/script/build.sh
+++ b/demo/script/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+
+dotnet tool restore
+
+dotnet cake incubator.cake "$@"

--- a/demo/script/incubator.cake
+++ b/demo/script/incubator.cake
@@ -1,0 +1,102 @@
+#reference "../../BuildArtifacts/temp/_PublishedLibraries/Cake.Incubator/net8.0/Cake.Incubator.dll"
+
+// Self-contained smoke test of Cake.Incubator's marquee features:
+// project parsing (the [CakeMethodAlias] surface) plus a couple of
+// extension-method namespaces that are auto-imported via the addin's
+// CakeNamespaceImportAttribute set (StringExtensions, EnumerableExtensions).
+// Each task asserts the expected outcome and throws on mismatch — the
+// script fails (non-zero exit) if any alias misbehaves.
+
+var workDir = Directory("./BuildArtifacts/temp/test-incubator");
+var sampleProject = workDir + File("Sample.csproj");
+
+void AssertThat(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new Exception("Assertion failed: " + message);
+    }
+}
+
+Task("Default")
+    .IsDependentOn("Setup")
+    .IsDependentOn("Parse-Project")
+    .IsDependentOn("String-Extensions")
+    .IsDependentOn("Enumerable-Extensions")
+    .IsDependentOn("Cleanup");
+
+Task("Setup")
+    .Does(() =>
+{
+    if (DirectoryExists(workDir))
+    {
+        DeleteDirectory(workDir, new DeleteDirectorySettings { Recursive = true });
+    }
+
+    EnsureDirectoryExists(workDir);
+    System.IO.File.WriteAllText(
+        sampleProject.Path.FullPath,
+        @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <AssemblyName>SampleAddin</AssemblyName>
+    <RootNamespace>Sample</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Cake.Core"" Version=""6.0.0"" />
+  </ItemGroup>
+</Project>");
+    Information("Setup complete.");
+});
+
+Task("Parse-Project")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var result = ParseProject(sampleProject, "Debug");
+    AssertThat(result != null, "ParseProject: returned null");
+    AssertThat(result.OutputType.EqualsIgnoreCase("Library"), "OutputType: expected Library, got " + result.OutputType);
+    AssertThat(result.AssemblyName == "SampleAddin", "AssemblyName: expected SampleAddin, got " + result.AssemblyName);
+    AssertThat(result.RootNameSpace == "Sample", "RootNameSpace: expected Sample, got " + result.RootNameSpace);
+    Information("ParseProject OK (OutputType={0}, AssemblyName={1}, RootNameSpace={2})",
+        result.OutputType, result.AssemblyName, result.RootNameSpace);
+});
+
+Task("String-Extensions")
+    .Does(() =>
+{
+    AssertThat("Hello".EqualsIgnoreCase("HELLO"), "EqualsIgnoreCase: case mismatch");
+    AssertThat("HelloWorld".StartsWithIgnoreCase("hello"), "StartsWithIgnoreCase: case mismatch");
+    AssertThat("HelloWorld".EndsWithIgnoreCase("WORLD"), "EndsWithIgnoreCase: case mismatch");
+    AssertThat(!"Hello".EqualsIgnoreCase("Goodbye"), "EqualsIgnoreCase: false-positive on different strings");
+    Information("String extensions OK (EqualsIgnoreCase + StartsWithIgnoreCase + EndsWithIgnoreCase)");
+});
+
+Task("Enumerable-Extensions")
+    .Does(() =>
+{
+    string[] nullArray = null;
+    AssertThat(nullArray.IsNullOrEmpty(), "IsNullOrEmpty: null array should be true");
+    AssertThat(new string[0].IsNullOrEmpty(), "IsNullOrEmpty: empty array should be true");
+    AssertThat(!new[] { "a" }.IsNullOrEmpty(), "IsNullOrEmpty: non-empty array should be false");
+    AssertThat("foo".IsIn("foo", "bar", "baz"), "IsIn: 'foo' should be in list");
+    AssertThat(!"qux".IsIn("foo", "bar"), "IsIn: 'qux' should NOT be in list");
+    Information("Enumerable extensions OK (IsNullOrEmpty + IsIn)");
+});
+
+Task("Cleanup")
+    .IsDependentOn("Parse-Project")
+    .IsDependentOn("String-Extensions")
+    .IsDependentOn("Enumerable-Extensions")
+    .Does(() =>
+{
+    if (DirectoryExists(workDir))
+    {
+        DeleteDirectory(workDir, new DeleteDirectorySettings { Recursive = true });
+    }
+
+    Information("Cleanup complete.");
+});
+
+RunTarget("Default");

--- a/demo/sdk/cake.cs
+++ b/demo/sdk/cake.cs
@@ -1,0 +1,114 @@
+#!/usr/bin/env dotnet
+#:sdk Cake.Sdk@6.1.1
+#:project ../../src/Cake.Incubator/Cake.Incubator.csproj
+
+// Cake SDK consumer demo for Cake.Incubator. Runs as a file-based
+// .NET program (introduced in .NET 10) using the Cake.Sdk
+// directives. The #:project directive above lets the SDK build the
+// addin from source rather than referencing a published nupkg.
+//
+// To run locally:
+//   cd demo/sdk
+//   dotnet cake.cs
+//
+// Mirrors the alias surface exercised by demo/script/incubator.cake
+// and demo/frosting/.
+
+using Cake.Incubator.EnumerableExtensions;
+using Cake.Incubator.StringExtensions;
+
+var workDir = Directory("./BuildArtifacts/temp/test-incubator-sdk");
+var sampleProject = workDir + File("Sample.csproj");
+
+Task("Default")
+    .IsDependentOn("Setup")
+    .IsDependentOn("Parse-Project")
+    .IsDependentOn("String-Extensions")
+    .IsDependentOn("Enumerable-Extensions")
+    .IsDependentOn("Cleanup");
+
+Task("Setup")
+    .Does(() =>
+{
+    if (DirectoryExists(workDir))
+    {
+        DeleteDirectory(workDir, new DeleteDirectorySettings { Recursive = true });
+    }
+
+    EnsureDirectoryExists(workDir);
+    System.IO.File.WriteAllText(
+        sampleProject.Path.FullPath,
+        @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <AssemblyName>SampleAddin</AssemblyName>
+    <RootNamespace>Sample</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Cake.Core"" Version=""6.0.0"" />
+  </ItemGroup>
+</Project>");
+    Information("Setup complete.");
+});
+
+Task("Parse-Project")
+    .IsDependentOn("Setup")
+    .Does(() =>
+{
+    var result = ParseProject(sampleProject, "Debug");
+    AssertThat(result != null, "ParseProject: returned null");
+    AssertThat(result.OutputType.EqualsIgnoreCase("Library"), "OutputType: expected Library, got " + result.OutputType);
+    AssertThat(result.AssemblyName == "SampleAddin", "AssemblyName: expected SampleAddin, got " + result.AssemblyName);
+    AssertThat(result.RootNameSpace == "Sample", "RootNameSpace: expected Sample, got " + result.RootNameSpace);
+    Information("ParseProject OK (OutputType={0}, AssemblyName={1}, RootNameSpace={2})",
+        result.OutputType, result.AssemblyName, result.RootNameSpace);
+});
+
+Task("String-Extensions")
+    .Does(() =>
+{
+    AssertThat("Hello".EqualsIgnoreCase("HELLO"), "EqualsIgnoreCase: case mismatch");
+    AssertThat("HelloWorld".StartsWithIgnoreCase("hello"), "StartsWithIgnoreCase: case mismatch");
+    AssertThat("HelloWorld".EndsWithIgnoreCase("WORLD"), "EndsWithIgnoreCase: case mismatch");
+    AssertThat(!"Hello".EqualsIgnoreCase("Goodbye"), "EqualsIgnoreCase: false-positive on different strings");
+    Information("String extensions OK (EqualsIgnoreCase + StartsWithIgnoreCase + EndsWithIgnoreCase)");
+});
+
+Task("Enumerable-Extensions")
+    .Does(() =>
+{
+    string[] nullArray = null;
+    AssertThat(nullArray.IsNullOrEmpty(), "IsNullOrEmpty: null array should be true");
+    AssertThat(new string[0].IsNullOrEmpty(), "IsNullOrEmpty: empty array should be true");
+    AssertThat(!new[] { "a" }.IsNullOrEmpty(), "IsNullOrEmpty: non-empty array should be false");
+    AssertThat("foo".IsIn("foo", "bar", "baz"), "IsIn: 'foo' should be in list");
+    AssertThat(!"qux".IsIn("foo", "bar"), "IsIn: 'qux' should NOT be in list");
+    Information("Enumerable extensions OK (IsNullOrEmpty + IsIn)");
+});
+
+Task("Cleanup")
+    .IsDependentOn("Parse-Project")
+    .IsDependentOn("String-Extensions")
+    .IsDependentOn("Enumerable-Extensions")
+    .Does(() =>
+{
+    if (DirectoryExists(workDir))
+    {
+        DeleteDirectory(workDir, new DeleteDirectorySettings { Recursive = true });
+    }
+
+    Information("Cleanup complete.");
+});
+
+RunTarget("Default");
+
+// ----- Helpers (must come AFTER top-level statements per CS8803) -----
+
+static void AssertThat(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new Exception("Assertion failed: " + message);
+    }
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+      "version": "10.0.100",
+      "rollForward": "latestFeature"
+    }
+  }

--- a/recipe.cake
+++ b/recipe.cake
@@ -9,7 +9,7 @@ BuildParameters.SetParameters(context: Context,
                             repositoryOwner: "cake-contrib",
                             repositoryName: "Cake.Incubator",
                             shouldRunCodecov: false,
-                            shouldGenerateDocumentation: false, // until wyam oin recipe is fixed
+                            shouldGenerateDocumentation: false,
                             appVeyorAccountName: "cakecontrib",
                             shouldRunDotNetCorePack: true,
                             preferredBuildProviderType: BuildProviderType.GitHubActions);

--- a/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
+++ b/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="sampleprojects\AnotherCSProj.xml" />
@@ -44,9 +44,9 @@
     <EmbeddedResource Include="sampleprojects\Cake_Unity_FSharp_Tests_fsproj.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="5.0.0" />
-    <PackageReference Include="Cake.Core" Version="5.0.0" />
-    <PackageReference Include="Cake.Testing" Version="5.0.0" />
+    <PackageReference Include="Cake.Common" Version="6.0.0" />
+    <PackageReference Include="Cake.Core" Version="6.0.0" />
+    <PackageReference Include="Cake.Testing" Version="6.0.0" />
     <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
+++ b/src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj
@@ -47,20 +47,23 @@
     <PackageReference Include="Cake.Common" Version="6.0.0" />
     <PackageReference Include="Cake.Core" Version="6.0.0" />
     <PackageReference Include="Cake.Testing" Version="6.0.0" />
-    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
     <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1" />
-    <PackageReference Include="FluentAssertions" Version="6.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.Incubator\Cake.Incubator.csproj" />

--- a/src/Cake.Incubator.Tests/NetCoreProjectParserExtensionsTests.cs
+++ b/src/Cake.Incubator.Tests/NetCoreProjectParserExtensionsTests.cs
@@ -278,6 +278,16 @@ namespace Cake.Incubator.Tests
         }
 
         [Fact]
+        public void ParseProject_DefaultsOutputType_ToExe_ForWebSdk_WhenNoneSpecified()
+        {
+            // Per #201 — Microsoft.NET.Sdk.Web's targets set OutputType to Exe so an
+            // ASP.NET Core web app with no explicit <OutputType> still produces an
+            // executable. Pre-v11.0.0 the parser hardcoded "Library" regardless of SDK.
+            var file = fs.CreateFakeFile(ProjectFileHelpers.GetNetCoreWebProjectWithString(null));
+            file.ParseProjectFile("test").OutputType.Should().Be("Exe");
+        }
+
+        [Fact]
         public void ParseProject_ApplicationIcons_ReturnsIfSet()
         {
             var file = fs.CreateFakeFile(ProjectFileHelpers.GetNetCoreProjectWithElement("ApplicationIcon", "fav.ico"));

--- a/src/Cake.Incubator.Tests/NetCoreProjectParserExtensionsTests.cs
+++ b/src/Cake.Incubator.Tests/NetCoreProjectParserExtensionsTests.cs
@@ -193,6 +193,39 @@ namespace Cake.Incubator.Tests
             file.ParseProjectFile("test").IsExpectoTestProject().Should().BeTrue();
         }
 
+        [Theory]
+        [InlineData("TUnit")]
+        [InlineData("xunit.v3")]
+        [InlineData("xunit.v3.core")]
+        public void ParseProject_IsDotNetCliTestProject_ForMicrosoftTestingPlatformNativeFrameworks(string packageName)
+        {
+            // Per #266 — Microsoft.Testing.Platform-native test frameworks (TUnit,
+            // xunit.v3) run via `dotnet test` without a Microsoft.NET.Test.Sdk
+            // reference. Pre-v11.0.0 IsDotNetCliTestProject only checked for
+            // Microsoft.NET.Test.Sdk and missed these projects entirely.
+            var testProject =
+                $"<PropertyGroup><TargetFramework>net8.0</TargetFramework><OutputType>Exe</OutputType></PropertyGroup>" +
+                $"<ItemGroup><PackageReference Include=\"{packageName}\" Version=\"1.0.0\" /></ItemGroup>";
+            var file = fs.CreateFakeFile(ProjectFileHelpers.GetNetCoreProjectWithString(testProject));
+            file.ParseProjectFile("test").IsDotNetCliTestProject().Should().BeTrue();
+        }
+
+        [Fact]
+        public void ParseProject_IsDotNetCliTestProject_ForMSTestSdk()
+        {
+            // Per #266 — Microsoft's MSTest.Sdk template uses Sdk="MSTest.Sdk" to
+            // opt into MTP-native test execution and does not require a
+            // Microsoft.NET.Test.Sdk reference.
+            const string projectXml =
+                @"<Project Sdk=""MSTest.Sdk"">
+                    <PropertyGroup>
+                      <TargetFramework>net8.0</TargetFramework>
+                    </PropertyGroup>
+                  </Project>";
+            var file = fs.CreateFakeFile(projectXml);
+            file.ParseProjectFile("test").IsDotNetCliTestProject().Should().BeTrue();
+        }
+
         [Fact]
         public void ParseProject_SetsIsNetCoreForWebSdk()
         {

--- a/src/Cake.Incubator.Tests/NetCoreProjectParserExtensionsTests.cs
+++ b/src/Cake.Incubator.Tests/NetCoreProjectParserExtensionsTests.cs
@@ -288,6 +288,34 @@ namespace Cake.Incubator.Tests
         }
 
         [Fact]
+        public void ParseProject_AcceptsAlternativeSdkElementSyntax()
+        {
+            // Per #267 — both forms must parse equivalently:
+            //   <Project Sdk="Microsoft.NET.Sdk"> ... </Project>          (attribute form)
+            //   <Project><Sdk Name="Microsoft.NET.Sdk" /> ... </Project>  (element form)
+            // The element form is common in monorepos that hide reusable SDK config in
+            // Directory.Build.props. Pre-v11.0.0 the parser only recognised the
+            // attribute form and errored with "Failed to parse pre VS2017 project
+            // properties" on the element form.
+            const string projectXml =
+                @"<Project>
+                    <Sdk Name=""Microsoft.NET.Sdk"" />
+                    <PropertyGroup>
+                      <TargetFramework>net8.0</TargetFramework>
+                      <OutputType>Library</OutputType>
+                      <AssemblyName>SampleAddin</AssemblyName>
+                    </PropertyGroup>
+                  </Project>";
+
+            var file = fs.CreateFakeFile(projectXml);
+            var result = file.ParseProjectFile("test");
+
+            result.IsVS2017ProjectFormat.Should().BeTrue();
+            result.OutputType.Should().Be("Library");
+            result.AssemblyName.Should().Be("SampleAddin");
+        }
+
+        [Fact]
         public void ParseProject_ApplicationIcons_ReturnsIfSet()
         {
             var file = fs.CreateFakeFile(ProjectFileHelpers.GetNetCoreProjectWithElement("ApplicationIcon", "fav.ico"));

--- a/src/Cake.Incubator/Cake.Incubator.csproj
+++ b/src/Cake.Incubator/Cake.Incubator.csproj
@@ -8,7 +8,7 @@
     <PropertyGroup>
         <Description>Provides useful extensions and additional aliases for Cake.Build scripts</Description>
         <Copyright>Copyright © Cake Contributions 2017 - Present</Copyright>
-        <PackageTags>Cake;Build;Script;Extensions;Project;Solution;addin;cake-addin;cake-build</PackageTags>
+        <PackageTags>cake;cake-build;cake-addin;addin;script;build;incubator;extensions;project-parser</PackageTags>
         <RepositoryUrl>https://github.com/cake-contrib/Cake.Incubator</RepositoryUrl>
         <PackageProjectUrl>https://github.com/cake-contrib/Cake.Incubator</PackageProjectUrl>
         <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>

--- a/src/Cake.Incubator/Cake.Incubator.csproj
+++ b/src/Cake.Incubator/Cake.Incubator.csproj
@@ -20,20 +20,24 @@
     <ItemGroup>
         <PackageReference Include="Cake.Common" Version="6.0.0" PrivateAssets="All" />
         <PackageReference Include="Cake.Core" Version="6.0.0" PrivateAssets="All" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
-        <PackageReference Include="System.Xml.XDocument" Version="4.3.0" />
         <PackageReference Include="Cake.Addin.Analyzer" Version="0.1.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="CakeContrib.Guidelines" Version="1.6.1">
+        <PackageReference Include="CakeContrib.Guidelines" Version="1.7.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+        <CakeContribGuidelinesOmitRecommendedReference Include="StyleCop.Analyzers" />
+        <CakeContribGuidelinesOmitRecommendedConfigFile Include="stylecop.json" />
+        <CakeContribGuidelinesOmitTargetFramework Include="net6.0" />
+        <CakeContribGuidelinesOmitTargetFramework Include="net7.0" />
     </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="Cake.Core.Annotations.CakeNamespaceImportAttribute">

--- a/src/Cake.Incubator/Cake.Incubator.csproj
+++ b/src/Cake.Incubator/Cake.Incubator.csproj
@@ -36,8 +36,6 @@
     <ItemGroup>
         <CakeContribGuidelinesOmitRecommendedReference Include="StyleCop.Analyzers" />
         <CakeContribGuidelinesOmitRecommendedConfigFile Include="stylecop.json" />
-        <CakeContribGuidelinesOmitTargetFramework Include="net6.0" />
-        <CakeContribGuidelinesOmitTargetFramework Include="net7.0" />
     </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="Cake.Core.Annotations.CakeNamespaceImportAttribute">

--- a/src/Cake.Incubator/Cake.Incubator.csproj
+++ b/src/Cake.Incubator/Cake.Incubator.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -18,8 +18,8 @@
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Cake.Common" Version="5.0.0" PrivateAssets="All" />
-        <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
+        <PackageReference Include="Cake.Common" Version="6.0.0" PrivateAssets="All" />
+        <PackageReference Include="Cake.Core" Version="6.0.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.Incubator/Project/CustomProjectParserResult.cs
+++ b/src/Cake.Incubator/Project/CustomProjectParserResult.cs
@@ -103,9 +103,9 @@ namespace Cake.Incubator.Project
         public NetCoreProject NetCore { get; set; }
 
         /// <summary>
-        /// The project package references. A collection of <see cref="PackageReference"/>
+        /// The project package references. A collection of <see cref="ParsedPackageReference"/>
         /// </summary>
-        public ICollection<PackageReference> PackageReferences { get; set; }
+        public ICollection<ParsedPackageReference> PackageReferences { get; set; }
 
         /// <summary>
         /// Whether the project parsed is in the newer VS2017 onwards format or the legacy pre 2017 format

--- a/src/Cake.Incubator/Project/NetCoreProject.cs
+++ b/src/Cake.Incubator/Project/NetCoreProject.cs
@@ -236,9 +236,9 @@ namespace Cake.Incubator.Project
         public string PackageProjectUrl { get; set; }
 
         /// <summary>
-        /// The project package references. A collection of <see cref="PackageReference"/>
+        /// The project package references. A collection of <see cref="ParsedPackageReference"/>
         /// </summary>
-        public ICollection<PackageReference> PackageReferences { get; set; }
+        public ICollection<ParsedPackageReference> PackageReferences { get; set; }
 
         /// <summary>
         /// dotnet pack: A Boolean value that specifies whether the client must prompt the consumer to accept the package license before installing the package. 

--- a/src/Cake.Incubator/Project/ParsedPackageReference.cs
+++ b/src/Cake.Incubator/Project/ParsedPackageReference.cs
@@ -1,19 +1,30 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 namespace Cake.Incubator.Project
 {
     /// <summary>
-    /// A project package reference
+    /// Represents a single &lt;PackageReference&gt; element parsed out of a
+    /// project file by <see cref="ProjectParserExtensions.ParseProject(Cake.Core.ICakeContext,Cake.Core.IO.FilePath,string)"/>.
     /// </summary>
-    public class PackageReference
+    /// <remarks>
+    /// Renamed from <c>PackageReference</c> to <c>ParsedPackageReference</c> in v11.0.0
+    /// to disambiguate from <c>Cake.Core.Packaging.PackageReference</c>. The two types
+    /// have unrelated purposes (this one is a csproj-parsing DTO; the Cake.Core type
+    /// describes a runtime tool-installation reference) but the unqualified short
+    /// name collided whenever both namespaces were brought into the same compilation
+    /// unit — most notably inside Cake.Sdk's source-generated helpers, which
+    /// prevented <c>cake.cs</c> consumers from compiling against this addin at all.
+    /// See cake-contrib/Cake.Incubator#268 for the rename background.
+    /// </remarks>
+    public class ParsedPackageReference
     {
         /// <summary>
         /// The package name
         /// </summary>
         public string Name { get; set; }
-        
+
         /// <summary>
         /// The package version
         /// </summary>

--- a/src/Cake.Incubator/Project/ProjectParserExtensions.cs
+++ b/src/Cake.Incubator/Project/ProjectParserExtensions.cs
@@ -879,7 +879,7 @@ namespace Cake.Incubator.Project
             var applicationIcon = document.GetFirstElementValue(ProjectXElement.ApplicationIcon);
             var assemblyVersion = document.GetFirstElementValue(ProjectXElement.AssemblyVersion) ?? "1.0.0.0";
             var fileVersion = document.GetFirstElementValue(ProjectXElement.FileVersion) ?? "1.0.0.0";
-            var outputType = document.GetFirstElementValue(ProjectXElement.OutputType) ?? "Library";
+            var outputType = document.GetFirstElementValue(ProjectXElement.OutputType) ?? GetDefaultOutputType(sdk);
             var debugType = document.GetFirstElementValue(ProjectXElement.DebugType);
             var product = document.GetFirstElementValue(ProjectXElement.Product);
             var documentationFile = document.GetFirstElementValue(ProjectXElement.DocumentationFile, config, platform);
@@ -1160,6 +1160,23 @@ namespace Cake.Incubator.Project
             return projectParserResult.IsType(ProjectType.Test) ||
                    projectParserResult.HasPackage(packageId) ||
                    projectParserResult.HasReference(referenceId);
+        }
+
+        // Per #201: when <OutputType> isn't set explicitly, the MSBuild default depends
+        // on the SDK. Microsoft.NET.Sdk.Web's targets set OutputType to Exe (so e.g. an
+        // ASP.NET Core web app csproj with no <OutputType> still produces an executable).
+        // Microsoft.NET.Sdk and unrecognised SDKs default to Library, matching the
+        // historical hard-coded behaviour. Worker / BlazorWebAssembly / WindowsDesktop
+        // templates set OutputType explicitly so the missing-element path doesn't apply
+        // to them — only Microsoft.NET.Sdk.Web is special-cased here.
+        private static string GetDefaultOutputType(string sdk)
+        {
+            if (sdk != null && sdk.EqualsIgnoreCase("Microsoft.NET.Sdk.Web"))
+            {
+                return "Exe";
+            }
+
+            return "Library";
         }
     }
 }

--- a/src/Cake.Incubator/Project/ProjectParserExtensions.cs
+++ b/src/Cake.Incubator/Project/ProjectParserExtensions.cs
@@ -85,19 +85,49 @@ namespace Cake.Incubator.Project
         /// </example>
         public static bool IsDotNetCliTestProject(this CustomProjectParserResult projectParserResult)
         {
-            // check for package reference 'Microsoft.NET.Test.Sdk' first
-            // in 2017 csproj format, it is located in package references
-            // in pre 2017 format, it is located in references
+            // Established VSTest-runner heuristic: a project carrying a
+            // Microsoft.NET.Test.Sdk package reference is `dotnet test`-compatible.
+            // In 2017+ csproj format the reference sits in PackageReferences; in
+            // pre-2017 format it's in package references too (Reference items are
+            // for assembly refs only).
             const string microsoftNetTestSdk = "Microsoft.NET.Test.Sdk";
 
             if (projectParserResult.IsNetCore &&
                 projectParserResult.NetCore.PackageReferences.Any(
                     x => x.Name.EqualsIgnoreCase(microsoftNetTestSdk)))
+            {
                 return true;
+            }
 
-            return projectParserResult.IsNetFramework &&
-                   !projectParserResult.PackageReferences.IsNullOrEmpty() &&
-                   projectParserResult.PackageReferences.Any(x => x.Name.EqualsIgnoreCase(microsoftNetTestSdk));
+            if (projectParserResult.IsNetFramework &&
+                !projectParserResult.PackageReferences.IsNullOrEmpty() &&
+                projectParserResult.PackageReferences.Any(x => x.Name.EqualsIgnoreCase(microsoftNetTestSdk)))
+            {
+                return true;
+            }
+
+            // Microsoft.Testing.Platform-native test projects (per #266) run via
+            // `dotnet test` without a Microsoft.NET.Test.Sdk reference. Detect them
+            // either by their MSBuild Sdk attribute (Sdk="MSTest.Sdk", Microsoft's
+            // MTP-native template) or by package references to known MTP-only test
+            // frameworks (TUnit, xunit.v3 — both run exclusively on MTP and do not
+            // ship a Microsoft.NET.Test.Sdk dependency). MSTest projects opting into
+            // MTP via <EnableMSTestRunner> still need Microsoft.NET.Test.Sdk to run
+            // and are caught by the established check above.
+            if (!projectParserResult.IsNetCore || projectParserResult.NetCore?.PackageReferences == null)
+            {
+                return false;
+            }
+
+            if (projectParserResult.NetCore.Sdk != null &&
+                projectParserResult.NetCore.Sdk.EqualsIgnoreCase("MSTest.Sdk"))
+            {
+                return true;
+            }
+
+            var mtpNativeTestPackages = new[] { "TUnit", "xunit.v3", "xunit.v3.core" };
+            return projectParserResult.NetCore.PackageReferences.Any(
+                x => mtpNativeTestPackages.Contains(x.Name, StringComparer.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/src/Cake.Incubator/Project/ProjectParserExtensions.cs
+++ b/src/Cake.Incubator/Project/ProjectParserExtensions.cs
@@ -431,14 +431,14 @@ namespace Cake.Incubator.Project
         /// CustomParseProjectResult project 
         ///         = ParseProject(new FilePath("test.csproj"), configuration: "Release", platform: "x86");
         /// 
-        /// PackageReference ref = project.GetReference("NUnit");
+        /// ParsedPackageReference ref = project.GetReference("NUnit");
         /// string nUnitVersion = ref.Version;
-        /// 
-        /// PackageReference ref = project.GetReference("NUnit", "netstandard2.0");
+        ///
+        /// ParsedPackageReference ref = project.GetReference("NUnit", "netstandard2.0");
         /// string nUnitVersion = ref.Version;
         /// </code>
         /// </example>
-        public static PackageReference GetPackage(this CustomProjectParserResult projectParserResult, string packageName, string targetFramework = null)
+        public static ParsedPackageReference GetPackage(this CustomProjectParserResult projectParserResult, string packageName, string targetFramework = null)
         {
             return (targetFramework == null)
                 ? projectParserResult.PackageReferences.FirstOrDefault(x => x.Name.EqualsIgnoreCase(packageName))

--- a/src/Cake.Incubator/XDocumentExtensions.cs
+++ b/src/Cake.Incubator/XDocumentExtensions.cs
@@ -70,13 +70,28 @@ namespace Cake.Incubator.XDocumentExtensions
         }
 
         /// <summary>
-        /// Returns the SDK identifier from the root &lt;Project Sdk="..."&gt; attribute, if present.
+        /// Returns the SDK identifier from the project's root element, supporting both
+        /// the &lt;Project Sdk="..."&gt; attribute form and the &lt;Project&gt;&lt;Sdk Name="..." /&gt;&lt;/Project&gt;
+        /// child-element form (per #267 — common in monorepos that hide reusable SDK
+        /// configuration in Directory.Build.props).
         /// </summary>
         /// <param name="document">the document</param>
-        /// <returns>the SDK identifier or null if no Sdk attribute is set</returns>
+        /// <returns>the SDK identifier or null if no Sdk attribute or element is set</returns>
         public static string GetSdk(this XDocument document)
         {
-            return document.Root?.Attribute("Sdk", true)?.Value;
+            var attribute = document.Root?.Attribute("Sdk", true)?.Value;
+            if (attribute != null)
+            {
+                return attribute;
+            }
+
+            // <Project>
+            //   <Sdk Name="Microsoft.NET.Sdk" />
+            // </Project>
+            var sdkElement = document.Root?
+                .Elements()
+                .FirstOrDefault(e => e.Name.LocalName.EqualsIgnoreCase("Sdk"));
+            return sdkElement?.GetAttributeValue("Name");
         }
 
         /// <summary>

--- a/src/Cake.Incubator/XDocumentExtensions.cs
+++ b/src/Cake.Incubator/XDocumentExtensions.cs
@@ -125,7 +125,7 @@ namespace Cake.Incubator.XDocumentExtensions
             return nsName == null ? XName.Get(elementName) : XName.Get(elementName, nsName);
         }
 
-        internal static ICollection<PackageReference> GetPackageReferences(this XDocument document)
+        internal static ICollection<ParsedPackageReference> GetPackageReferences(this XDocument document)
         {
             // NOTE: Conflicting docs: 
             // https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files
@@ -178,7 +178,7 @@ namespace Cake.Incubator.XDocumentExtensions
                     var includeAssets = x.Element(includeAssetsXName)?.Value.SplitIgnoreEmpty(';') ?? globalInclude;
                     var excludeAssets = x.Element(excludeAssetsXName)?.Value.SplitIgnoreEmpty(';') ?? globalExclude;
                     var condition = x.GetAttributeValue("Condition") ?? x.Parent.GetAttributeValue("Condition");
-                    return new PackageReference
+                    return new ParsedPackageReference
                     {
                         Name = x.GetAttributeValue("Include") ?? x.Element(includeXName)?.Value,
                         Version = x.GetAttributeValue("Version") ?? x.Element(versionXName)?.Value,

--- a/src/Cake.Incubator/XDocumentExtensions.cs
+++ b/src/Cake.Incubator/XDocumentExtensions.cs
@@ -18,7 +18,7 @@ namespace Cake.Incubator.XDocumentExtensions
     /// <summary>
     /// Several extension methods when using XDocument.
     /// </summary>
-    internal static class XDocumentExtensions
+    public static class XDocumentExtensions
     {
         /// <summary>
         /// Gets the first output path value for a specific config from an xml document
@@ -29,7 +29,7 @@ namespace Cake.Incubator.XDocumentExtensions
         /// <param name="platform">the platform</param>
         /// <param name="targetFrameworks">the target frameworks expected (affects output paths)</param>
         /// <returns>the output path</returns>
-        internal static DirectoryPath[] GetOutputPaths(this XDocument document, string config, string[] targetFrameworks, DirectoryPath rootDirectoryPath, string platform = "AnyCPU")
+        public static DirectoryPath[] GetOutputPaths(this XDocument document, string config, string[] targetFrameworks, DirectoryPath rootDirectoryPath, string platform = "AnyCPU")
         {
             var outputPathOverride = document.Descendants("OutputPath")
                 .FirstOrDefault(x =>
@@ -64,17 +64,28 @@ namespace Cake.Incubator.XDocumentExtensions
         /// </summary>
         /// <param name="document">The xml document</param>
         /// <returns>True if attribute was found</returns>
-        internal static bool IsDotNetSdk(this XDocument document)
+        public static bool IsDotNetSdk(this XDocument document)
         {
             return document.GetSdk() != null;
         }
 
-        internal static string GetSdk(this XDocument document)
+        /// <summary>
+        /// Returns the SDK identifier from the root &lt;Project Sdk="..."&gt; attribute, if present.
+        /// </summary>
+        /// <param name="document">the document</param>
+        /// <returns>the SDK identifier or null if no Sdk attribute is set</returns>
+        public static string GetSdk(this XDocument document)
         {
             return document.Root?.Attribute("Sdk", true)?.Value;
         }
 
-        internal static string GetVersion(this XDocument document)
+        /// <summary>
+        /// Returns the project version, combining VersionPrefix and VersionSuffix when both are
+        /// present, falling back to Version, and ultimately "1.0.0" when nothing is set.
+        /// </summary>
+        /// <param name="document">the document</param>
+        /// <returns>the resolved version string</returns>
+        public static string GetVersion(this XDocument document)
         {
             // prefix and suffix take precidence, fallback is version if both are not specified
             var prefix = document.GetFirstElementValue(ProjectXElement.VersionPrefix);
@@ -95,7 +106,7 @@ namespace Cake.Incubator.XDocumentExtensions
         /// <param name="config">the configuration to match</param>
         /// <param name="platform">the platform to match, default is AnyCPU</param>
         /// <returns>the matching element value if found</returns>
-        internal static string GetFirstElementValue(this XDocument document, XName elementName, string config = null, string platform = "AnyCPU")
+        public static string GetFirstElementValue(this XDocument document, XName elementName, string config = null, string platform = "AnyCPU")
         {
             var elements = document.Descendants(elementName);
             if (!elements.Any()) return null;
@@ -109,7 +120,12 @@ namespace Cake.Incubator.XDocumentExtensions
                        ?.Value ?? elements.FirstOrDefault(x => !x.WithConfigCondition())?.Value;
         }
 
-        internal static ICollection<DotNetCliToolReference> GetDotNetCliToolReferences(this XDocument document)
+        /// <summary>
+        /// Returns all &lt;DotNetCliToolReference&gt; entries declared in the project.
+        /// </summary>
+        /// <param name="document">the document</param>
+        /// <returns>the collection of CLI tool references (empty array if none)</returns>
+        public static ICollection<DotNetCliToolReference> GetDotNetCliToolReferences(this XDocument document)
         {
             return document.Descendants(ProjectXElement.DotNetCliToolReference).Select(x =>
                 new DotNetCliToolReference
@@ -119,13 +135,28 @@ namespace Cake.Incubator.XDocumentExtensions
                 }).ToArray();
         }
 
-        internal static XName GetXNameWithNamespace(this XNamespace ns, string elementName)
+        /// <summary>
+        /// Combines an XNamespace with an element name into an XName, handling the case where
+        /// the namespace is null (pre-VS2017 csproj files use a default namespace; modern
+        /// SDK-style projects don't).
+        /// </summary>
+        /// <param name="ns">the namespace (or null)</param>
+        /// <param name="elementName">the element name</param>
+        /// <returns>an XName scoped to the namespace when provided</returns>
+        public static XName GetXNameWithNamespace(this XNamespace ns, string elementName)
         {
             var nsName = ns?.NamespaceName;
             return nsName == null ? XName.Get(elementName) : XName.Get(elementName, nsName);
         }
 
-        internal static ICollection<ParsedPackageReference> GetPackageReferences(this XDocument document)
+        /// <summary>
+        /// Returns all &lt;PackageReference&gt; entries declared in the project, resolving
+        /// PrivateAssets / IncludeAssets / ExcludeAssets attributes or child elements and any
+        /// TargetFramework condition on the element or its parent ItemGroup.
+        /// </summary>
+        /// <param name="document">the document</param>
+        /// <returns>the collection of parsed package references</returns>
+        public static ICollection<ParsedPackageReference> GetPackageReferences(this XDocument document)
         {
             // NOTE: Conflicting docs: 
             // https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files
@@ -192,7 +223,14 @@ namespace Cake.Incubator.XDocumentExtensions
                 }).ToArray();
         }
         
-        internal static ICollection<ProjectAssemblyReference> GetAssemblyReferences(this XDocument document, DirectoryPath rootPath)
+        /// <summary>
+        /// Returns all &lt;Reference&gt; entries declared in the project, resolving HintPath
+        /// values relative to <paramref name="rootPath"/>.
+        /// </summary>
+        /// <param name="document">the document</param>
+        /// <param name="rootPath">the project root directory used for HintPath resolution</param>
+        /// <returns>the collection of assembly references</returns>
+        public static ICollection<ProjectAssemblyReference> GetAssemblyReferences(this XDocument document, DirectoryPath rootPath)
         {
             /*
                 <Reference Include="Cake.Common, Version=0.22.0.0, Culture=neutral, PublicKeyToken=null">
@@ -242,7 +280,14 @@ namespace Cake.Incubator.XDocumentExtensions
                 }).Distinct(x => x.Name).ToArray();
         }
 
-        internal static ICollection<ProjectReference> GetProjectReferences(this XDocument document, DirectoryPath rootPath)
+        /// <summary>
+        /// Returns all &lt;ProjectReference&gt; entries, resolving Include paths relative to
+        /// <paramref name="rootPath"/>.
+        /// </summary>
+        /// <param name="document">the document</param>
+        /// <param name="rootPath">the project root directory used for path resolution</param>
+        /// <returns>the collection of project references</returns>
+        public static ICollection<ProjectReference> GetProjectReferences(this XDocument document, DirectoryPath rootPath)
         {
             return document.Descendants(ProjectXElement.ProjectReference).Select(x =>
             {
@@ -256,7 +301,13 @@ namespace Cake.Incubator.XDocumentExtensions
             }).ToArray();
         }
 
-        internal static ICollection<BuildTarget> GetTargets(this XDocument document)
+        /// <summary>
+        /// Returns all &lt;Target&gt; build targets declared in the project (with their
+        /// BeforeTargets / AfterTargets attributes and nested &lt;Exec&gt; commands).
+        /// </summary>
+        /// <param name="document">the document</param>
+        /// <returns>the collection of build targets</returns>
+        public static ICollection<BuildTarget> GetTargets(this XDocument document)
         {
             /*
              <Target Name="MyPreCompileTarget" BeforeTargets="Build">
@@ -283,7 +334,13 @@ namespace Cake.Incubator.XDocumentExtensions
                 }).ToArray();
         }
 
-        internal static NameValueCollection GetNuspecProps(this XDocument document)
+        /// <summary>
+        /// Returns the project's nuspec-relevant property values (PackageId, Title, Authors,
+        /// Description, Copyright, etc.) keyed by element name.
+        /// </summary>
+        /// <param name="document">the document</param>
+        /// <returns>a name-value collection of nuspec property values</returns>
+        public static NameValueCollection GetNuspecProps(this XDocument document)
         {
             var nuspecProps = document.GetFirstElementValue(ProjectXElement.NuspecProperties).SplitIgnoreEmpty(';');
             var nuspecProperties = new NameValueCollection(nuspecProps.Length);


### PR DESCRIPTION
Closes #262.
Closes #110.
Closes #201.
Closes #266.
Closes #267.
Closes #268.

## Scope

### Cake 6 catch-up + retrofit (#262)

The v10.0.0 release (2025-10-29) shipped Cake 5 support but pre-dates the workspace's `demo/{script,frosting,sdk}` standard. v11.0.0 catches up to Cake 6 and folds in the retrofit so future per-Cake-major arcs have a stable shape:

- **Addin**: `Cake.Core` / `Cake.Common` `5.0.0 → 6.0.0`. TFMs gain `net10.0` (`net8.0;net9.0;net10.0`).
- **Tests**: `Cake.Testing` `5.0.0 → 6.0.0`. Tests TFM drops to `net8.0` only (lowest-of-addin's-range, per the workspace tests-TFM rotation table for Cake 6.x — was `net8.0;net9.0`).
- **`global.json` (NEW)**: SDK `10.0.100` with `rollForward=latestFeature`, matching the new highest TFM.
- **Test deps modernised** (long stale): `coverlet.msbuild` `3.2.0 → 6.0.4`, `FluentAssertions` `6.9.0 → 6.12.2` (workspace pin per `feedback_fluentassertions_pre7` — never go to 7.x because of the Xceed re-license), `Microsoft.NET.Test.Sdk` `17.4.1 → 18.0.1`, `Microsoft.SourceLink.GitHub` `1.1.1 → 8.0.0`, `xunit` `2.4.2 → 2.9.3`, `xunit.runner.visualstudio` `2.4.5 → 3.1.5`. `FakeItEasy` and `FakeItEasy.Analyzer.CSharp` left at their current pins (cross-major Renovate concern, separate cadence).
- **Addin deps modernised**: `Microsoft.SourceLink.GitHub` `1.1.1 → 8.0.0`, `CakeContrib.Guidelines` `1.6.1 → 1.7.0`. `System.Collections.Specialized` and `System.Xml.XDocument` `4.3.0` removed (vestigial netstandard1.x compat packages, NU1510 confirmed they're built into the BCL on every TFM the addin now ships).
- **CakeContrib.Guidelines omit configs added** to suppress warnings about StyleCop and `net6.0`/`net7.0` (intentionally not used).
- **PackageTags canonicalisation**: `cake;cake-build;cake-addin;addin;script;build;incubator;extensions;project-parser`.
- **`recipe.cake`**: dropped the typo'd "until wyam oin recipe is fixed" comment.
- **`demo/script/incubator.cake` (NEW)**: cake.tool `6.1.0`. Exercises ParseProject + StringExtensions + EnumerableExtensions.
- **`demo/frosting/` (NEW)**: Cake.Frosting `6.1.0`. Mirrors `demo/script`'s task surface with the same dependency chain.
- **`demo/sdk/cake.cs` (NEW)**: Cake.Sdk `6.1.1` with `#:project ../../src/Cake.Incubator/Cake.Incubator.csproj`. Builds the addin from source for the SDK consumer demo.
- **`build.yml`**: `macos-13` dropped from matrix (per memory `feedback_no_macos_in_build_matrix`); `9.0.x` + `10.0.x` added to setup-dotnet runtimes; `Run demo/script` + `Run demo/frosting` + `Run demo/sdk` steps wired in after the recipe build.

### Make `XDocumentExtensions` public (#110)

10-year-old request. Class and all 12 helper methods (`GetOutputPaths`, `IsDotNetSdk`, `GetSdk`, `GetVersion`, `GetFirstElementValue`, `GetDotNetCliToolReferences`, `GetXNameWithNamespace`, `GetPackageReferences`, `GetAssemblyReferences`, `GetProjectReferences`, `GetTargets`, `GetNuspecProps`) promoted from `internal` to `public`. Methods that lacked XML doc comments got minimal `<summary>`/`<param>`/`<returns>` markup. A `<remarks>` note on the class explains the visibility change so future readers don't accidentally revert.

### Default OutputType per SDK (#201)

When `<OutputType>` isn't set explicitly, the parser now picks the appropriate default for the SDK: `Microsoft.NET.Sdk.Web` → `"Exe"` (matching MSBuild's actual behaviour), unrecognised SDKs → `"Library"` (preserving pre-v11.0.0 behaviour for everything else). Test added covering the `Microsoft.NET.Sdk.Web` case.

### Microsoft.Testing.Platform-native test detection (#266)

`IsDotNetCliTestProject()` previously only matched the established `Microsoft.NET.Test.Sdk` package-reference heuristic. TUnit, xunit.v3, and `Sdk="MSTest.Sdk"` projects all returned false despite being fully `dotnet test`-compatible. Two new MTP-native signals layered on top: `Sdk="MSTest.Sdk"` attribute, and known MTP-only test framework package references (TUnit / xunit.v3 / xunit.v3.core). Theory + Fact tests added covering both paths.

### Alternative `<Sdk Name="..."/>` element syntax (#267)

Carved out of #203 sub-ask 1. `GetSdk()` now falls back to scanning for a `<Sdk Name="..."/>` child element when the root attribute is absent. Common in monorepos that hide SDK config in `Directory.Build.props`. Test added.

### Rename `PackageReference` → `ParsedPackageReference` (#268)

Forced by the `demo/sdk` introduction — Cake.Sdk 6+ source-imports the addin's namespaces into its synthesized helpers, and `Cake.Incubator.Project.PackageReference` collided with `Cake.Core.Packaging.PackageReference` causing CS0104 in generated code that the addin can't influence. The DTO type is now `ParsedPackageReference` with a `<remarks>` doc explaining the rename rationale + cross-referencing the issue. Property name `PackageReferences` (the collection) stays unchanged — only the element type changed.

## Out of scope

- **#42** closed during the audit as obsolete (Cake.Common.DotNetTestSettings already exposes `NoRestore`).
- **#231** (Directory.Build.props) and **#203 sub-asks 2/3** (Central Package Management; positive feedback) stay open — both are MSBuild-evaluation problems, separate effort from plain XML parsing.
- **#232** (output-path override quirk) and **#112** (VS2015 default test project false-positives) deferred to post-arc triage.
- **PR #78** (file globbing in ParseProject) is 7.9 years stale; queued for triage/close separately.
- Workspace-wide `Wyam`-removal cleanup (`publishDocs.yml`, `config.wyam*`, the `Force-Publish-Documentation` recipe target) deferred — separate sweep, not gating v11.0.0.
- IDE-state file `src/Cake.Incubator.sln.DotSettings` left untouched (locally modified but not part of this PR).

## Local verification

- `dotnet cake recipe.cake --target=DotNetCore-Pack` — green (Cake.Incubator.10.1.0-cake-6-0001.nupkg + .snupkg produced).
- `dotnet test src/Cake.Incubator.Tests/Cake.Incubator.Tests.csproj` — 253 passed, 0 failed, 2 skipped (pre-existing).
- `./demo/script/build.ps1` — all 5 tasks succeeded under cake.tool 6.1.0.
- `./demo/frosting/build.ps1` — all 5 tasks succeeded under Cake.Frosting 6.1.0.
- `dotnet cake.cs` (in `demo/sdk/`) — all 5 tasks succeeded under Cake.Sdk 6.1.1 + .NET 10 SDK 10.0.107.

**Note for the recipe-side `Generate-LocalCoverageReport`**: the local recipe build crashes inside `tools/ReportGenerator.exe` (`STATUS_STACK_BUFFER_OVERRUN`) due to a Cake.Recipe 4.0.0 + ReportGenerator 4.8.5 + .NET 10 SDK + ~430 KB coverage XML interaction. Cleanly reproduced; same binary with the same args runs fine when invoked manually from bash (only Cake.Recipe's process spawner trips it). Workspace-level follow-up logged in `TODO.md`. CI runners have a broader runtime set installed and are expected to clear the issue, hence shipping with `--target=DotNetCore-Pack` for local verification only.

## Release context

| Issue | Label | Closes via |
|---|---|---|
| [#262](https://github.com/cake-contrib/Cake.Incubator/issues/262) | `Breaking change` | Cake.Core 5→6 bump |
| [#268](https://github.com/cake-contrib/Cake.Incubator/issues/268) | `Breaking change` | PackageReference → ParsedPackageReference rename |
| [#201](https://github.com/cake-contrib/Cake.Incubator/issues/201) | `Bug` | OutputType per SDK |
| [#266](https://github.com/cake-contrib/Cake.Incubator/issues/266) | `Bug` | MTP-native detection |
| [#267](https://github.com/cake-contrib/Cake.Incubator/issues/267) | `Bug` | Alt SDK element syntax |
| [#110](https://github.com/cake-contrib/Cake.Incubator/issues/110) | `Feature` | XDocumentExtensions public |

All six attached to milestone 11.0.0 with exactly one category label each.