### PR TITLE
(maint) Ignore *.lscache language-service cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,6 @@ __pycache__/
 # Cake - Uncomment if you are using it
 tools/**
 BuildArtifacts/
+
+# Language service cache files (e.g. Roslyn / IDE language servers)
+*.lscache


### PR DESCRIPTION
Quick csproj-hygiene cleanup spotted in the v11.0.0 catch-up aftermath
(#269) — Cake.Incubator's `.gitignore` was missing the `*.lscache`
rule that the rest of the workspace baselines on.

Without it, JetBrains Rider / ReSharper produce `<csproj-name>.lscache`
files next to every csproj after a language-service parse, which then
show up as untracked under `git status` and risk slipping into commits
on a `git add <directory>/`. The v11.0.0 PR demo/frosting commit (`6b2d550`)
accidentally pulled one in for that reason — caught and dropped via
`git rm --cached` mid-flight, but the underlying gap was the missing
ignore rule.

Cake.FileHelpers' [.gitignore line 21](https://github.com/cake-contrib/Cake.FileHelpers/blob/develop/.gitignore#L21)
has the same rule with the same comment block; this aligns Cake.Incubator
to that shape.

Drive-by: trailing newline at EOF added (file was previously missing one).